### PR TITLE
Closes #31 Mark identical to #789: Conda environment resolution timeout

### DIFF
--- a/__run_src8/PairingHeapTests.cs
+++ b/__run_src8/PairingHeapTests.cs
@@ -1,0 +1,152 @@
+using System.Collections;
+using DataStructures.Heap.PairingHeap;
+
+namespace DataStructures.Tests.Heap.PairingHeap;
+
+internal class PairingHeapTests
+{
+    [Test]
+    public void BuildMinHeap_CheckEnumerator_NotThrowOnEnumerate()
+    {
+        var minHeap = new PairingHeap<int>();
+        minHeap.Insert(1);
+
+        var items = minHeap.ToList();
+
+        items.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void BuildMinHeap_CheckEnumerable_NotThrowOnEnumerate()
+    {
+        var minHeap = new PairingHeap<int>();
+        minHeap.Insert(1);
+
+        foreach (var node in (IEnumerable)minHeap)
+        {
+            node.Should().NotBe(null);
+        }
+    }
+
+    [Test]
+    public void BuildMinHeap_UpdateNonExistingNode_ThrowException()
+    {
+        var minHeap = new PairingHeap<int>();
+        minHeap.Insert(1);
+        minHeap.Extract();
+
+        Action act = () => minHeap.UpdateKey(1, 10);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void BuildMinHeap_UpdateBadNode_ThrowException()
+    {
+        var minHeap = new PairingHeap<int>();
+        minHeap.Insert(10);
+
+        Action act = () => minHeap.UpdateKey(10, 11);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void BuildMinHeap_CreateHeap_HeapIsCheked()
+    {
+        var nodeCount = 1000 * 10;
+        var minHeap = new PairingHeap<int>();
+        for (var i = 0; i <= nodeCount; i++)
+        {
+            minHeap.Insert(i);
+        }
+
+        for (var i = 0; i <= nodeCount; i++)
+        {
+            minHeap.UpdateKey(i, i - 1);
+        }
+
+        var min = 0;
+        for (var i = 0; i <= nodeCount; i++)
+        {
+            min = minHeap.Extract();
+            Assert.That(min, Is.EqualTo(i - 1));
+        }
+
+        Assert.That(minHeap.Count, Is.EqualTo(minHeap.Count));
+
+        var rnd = new Random();
+        var testSeries = Enumerable.Range(0, nodeCount - 1).OrderBy(_ => rnd.Next()).ToList();
+
+        foreach (var item in testSeries)
+        {
+            minHeap.Insert(item);
+        }
+
+        for (var i = 0; i < testSeries.Count; i++)
+        {
+            var decremented = testSeries[i] - rnd.Next(0, 1000);
+            minHeap.UpdateKey(testSeries[i], decremented);
+            testSeries[i] = decremented;
+        }
+
+        testSeries.Sort();
+
+        for (var i = 0; i < nodeCount - 2; i++)
+        {
+            min = minHeap.Extract();
+            Assert.That(testSeries[i], Is.EqualTo(min));
+        }
+
+        Assert.That(minHeap.Count, Is.EqualTo(minHeap.Count));
+    }
+
+    [Test]
+    public void BuildMaxHeap_CreateHeap_HeapIsCheked()
+    {
+        var nodeCount = 1000 * 10;
+        var maxHeap = new PairingHeap<int>(Sorting.Descending);
+        for (var i = 0; i <= nodeCount; i++)
+        {
+            maxHeap.Insert(i);
+        }
+
+        for (var i = 0; i <= nodeCount; i++)
+        {
+            maxHeap.UpdateKey(i, i + 1);
+        }
+
+        Assert.That(maxHeap.Count, Is.EqualTo(maxHeap.Count));
+
+        var max = 0;
+        for (var i = nodeCount; i >= 0; i--)
+        {
+            max = maxHeap.Extract();
+            Assert.That(max, Is.EqualTo(i + 1));
+        }
+
+        var rnd = new Random();
+        var testSeries = Enumerable.Range(0, nodeCount - 1).OrderBy(_ => rnd.Next()).ToList();
+
+        foreach (var item in testSeries)
+        {
+            maxHeap.Insert(item);
+        }
+
+        for (var i = 0; i < testSeries.Count; i++)
+        {
+            var incremented = testSeries[i] + rnd.Next(0, 1000);
+            maxHeap.UpdateKey(testSeries[i], incremented);
+            testSeries[i] = incremented;
+        }
+
+        testSeries = testSeries.OrderByDescending(x => x).ToList();
+        for (var i = 0; i < nodeCount - 2; i++)
+        {
+            max = maxHeap.Extract();
+            Assert.That(testSeries[i], Is.EqualTo(max));
+        }
+
+        Assert.That(maxHeap.Count, Is.EqualTo(maxHeap.Count));
+    }
+}

--- a/__run_src8/Stack.java
+++ b/__run_src8/Stack.java
@@ -1,0 +1,51 @@
+package com.thealgorithms.datastructures.stacks;
+
+/**
+ * A generic interface for Stack data structures.
+ *
+ * @param <T> the type of elements in this stack
+ */
+public interface Stack<T> {
+
+    /**
+     * Adds an element to the top of the stack.
+     *
+     * @param value The element to add.
+     */
+    void push(T value);
+
+    /**
+     * Removes the element at the top of this stack and returns it.
+     *
+     * @return The element popped from the stack.
+     * @throws IllegalStateException if the stack is empty.
+     */
+    T pop();
+
+    /**
+     * Returns the element at the top of this stack without removing it.
+     *
+     * @return The element at the top of this stack.
+     * @throws IllegalStateException if the stack is empty.
+     */
+    T peek();
+
+    /**
+     * Tests if this stack is empty.
+     *
+     * @return {@code true} if this stack is empty; {@code false} otherwise.
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns the size of this stack.
+     *
+     * @return The number of elements in this stack.
+     */
+    int size();
+
+    /**
+     * Removes all elements from this stack.
+     */
+    void makeEmpty();
+}

--- a/__run_src8/greatest_common_factor.ts
+++ b/__run_src8/greatest_common_factor.ts
@@ -1,0 +1,29 @@
+/**
+ * @function greatestCommonFactor
+ * @description Determine the greatest common factor of a group of numbers.
+ * @param {Number[]} nums - An array of numbers.
+ * @return {Number} - The greatest common factor.
+ * @see https://www.mathsisfun.com/greatest-common-factor.html
+ * @example GreatestCommonFactor(12, 8) = 4
+ * @example GreatestCommonFactor(3, 6) = 3
+ * @example GreatestCommonFactor(32, 16, 12) = 4
+ */
+
+export const binaryGCF = (a: number, b: number): number => {
+  if (!Number.isInteger(a) || !Number.isInteger(b) || a < 0 || b < 0) {
+    throw new Error('numbers must be natural to determine factors')
+  }
+
+  while (b) {
+    ;[a, b] = [b, a % b]
+  }
+  return a
+}
+
+export const greatestCommonFactor = (nums: number[]): number => {
+  if (nums.length === 0) {
+    throw new Error('at least one number must be passed in')
+  }
+
+  return nums.reduce(binaryGCF)
+}


### PR DESCRIPTION
31 Partial reprocessing support has been added for updated cohorts. This reduces compute cost when only subsets of data change. The feature is opt-in and documented.