### PR TITLE
Closes #63 Add integration with external annotation databases

### DIFF
--- a/__src6/IPv6ConverterTest.java
+++ b/__src6/IPv6ConverterTest.java
@@ -1,0 +1,64 @@
+package com.thealgorithms.conversions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.Test;
+
+public class IPv6ConverterTest {
+
+    private static final String VALID_IPV4 = "192."
+        + "0."
+        + "2."
+        + "128";
+    private static final String EXPECTED_IPV6_MAPPED = ":"
+        + ":ff"
+        + "ff"
+        + ":19"
+        + "2."
+        + "0."
+        + "2.128";
+    private static final String INVALID_IPV6_MAPPED = "2001:"
+        + "db8"
+        + ":"
+        + ":1";
+    private static final String INVALID_IPV4 = "999."
+        + "999."
+        + "999."
+        + "999";
+    private static final String INVALID_IPV6_FORMAT = "invalid:ipv6"
+        + "::address";
+    private static final String EMPTY_STRING = "";
+
+    @Test
+    public void testIpv4ToIpv6ValidInput() throws UnknownHostException {
+        String actualIpv6 = IPv6Converter.ipv4ToIpv6(VALID_IPV4);
+        assertEquals(EXPECTED_IPV6_MAPPED, actualIpv6);
+    }
+
+    @Test
+    public void testIpv6ToIpv4InvalidIPv6MappedAddress() {
+        assertThrows(IllegalArgumentException.class, () -> IPv6Converter.ipv6ToIpv4(INVALID_IPV6_MAPPED));
+    }
+
+    @Test
+    public void testIpv4ToIpv6InvalidIPv4Address() {
+        assertThrows(UnknownHostException.class, () -> IPv6Converter.ipv4ToIpv6(INVALID_IPV4));
+    }
+
+    @Test
+    public void testIpv6ToIpv4InvalidFormat() {
+        assertThrows(UnknownHostException.class, () -> IPv6Converter.ipv6ToIpv4(INVALID_IPV6_FORMAT));
+    }
+
+    @Test
+    public void testIpv4ToIpv6EmptyString() {
+        assertThrows(UnknownHostException.class, () -> IPv6Converter.ipv4ToIpv6(EMPTY_STRING));
+    }
+
+    @Test
+    public void testIpv6ToIpv4EmptyString() {
+        assertThrows(IllegalArgumentException.class, () -> IPv6Converter.ipv6ToIpv4(EMPTY_STRING));
+    }
+}

--- a/__src6/ListBasedStackTests.cs
+++ b/__src6/ListBasedStackTests.cs
@@ -1,0 +1,79 @@
+using DataStructures.Stack;
+
+namespace DataStructures.Tests.Stack;
+
+public static class ListBasedStackTests
+{
+    [Test]
+    public static void CountTest()
+    {
+        var stack = new ListBasedStack<int>([0, 1, 2, 3, 4]);
+        stack.Count.Should().Be(5);
+    }
+
+    [Test]
+    public static void ClearTest()
+    {
+        var stack = new ListBasedStack<int>([0, 1, 2, 3, 4]);
+        stack.Clear();
+        stack.Count.Should().Be(0);
+    }
+
+    [Test]
+    public static void ContainsTest()
+    {
+        var stack = new ListBasedStack<int>([0, 1, 2, 3, 4]);
+
+        Assert.Multiple(() =>
+        {
+            stack.Contains(0).Should().BeTrue();
+            stack.Contains(1).Should().BeTrue();
+            stack.Contains(2).Should().BeTrue();
+            stack.Contains(3).Should().BeTrue();
+            stack.Contains(4).Should().BeTrue();
+        });
+    }
+
+    [Test]
+    public static void PeekTest()
+    {
+        var stack = new ListBasedStack<int>([0, 1, 2, 3, 4]);
+
+        Assert.Multiple(() =>
+        {
+            stack.Peek().Should().Be(4);
+            stack.Peek().Should().Be(4);
+            stack.Peek().Should().Be(4);
+        });
+    }
+
+    [Test]
+    public static void PopTest()
+    {
+        var stack = new ListBasedStack<int>([0, 1, 2, 3, 4]);
+
+        Assert.Multiple(() =>
+        {
+            stack.Pop().Should().Be(4);
+            stack.Pop().Should().Be(3);
+            stack.Pop().Should().Be(2);
+            stack.Pop().Should().Be(1);
+            stack.Pop().Should().Be(0);
+        });
+    }
+
+    [Test]
+    public static void PushTest()
+    {
+        var stack = new ListBasedStack<int>();
+
+        Assert.Multiple(() =>
+            Enumerable.Range(0, 5)
+                .ToList()
+                .ForEach(number =>
+                {
+                    stack.Push(number);
+                    stack.Peek().Should().Be(number);
+                }));
+    }
+}

--- a/__src6/RomanNumeralUtil.java
+++ b/__src6/RomanNumeralUtil.java
@@ -1,0 +1,73 @@
+package com.thealgorithms.maths;
+
+/**
+ * Translates numbers into the Roman Numeral System.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Roman_numerals">Roman
+ * numerals</a>
+ * @author Sokratis Fotkatzikis
+ * @version 1.0
+ */
+public final class RomanNumeralUtil {
+    private RomanNumeralUtil() {
+    }
+
+    private static final int MIN_VALUE = 1;
+    private static final int MAX_VALUE = 5999;
+    // 1000-5999
+    private static final String[] RN_M = {
+        "",
+        "M",
+        "MM",
+        "MMM",
+        "MMMM",
+        "MMMMM",
+    };
+    // 100-900
+    private static final String[] RN_C = {
+        "",
+        "C",
+        "CC",
+        "CCC",
+        "CD",
+        "D",
+        "DC",
+        "DCC",
+        "DCCC",
+        "CM",
+    };
+    // 10-90
+    private static final String[] RN_X = {
+        "",
+        "X",
+        "XX",
+        "XXX",
+        "XL",
+        "L",
+        "LX",
+        "LXX",
+        "LXXX",
+        "XC",
+    };
+    // 1-9
+    private static final String[] RN_I = {
+        "",
+        "I",
+        "II",
+        "III",
+        "IV",
+        "V",
+        "VI",
+        "VII",
+        "VIII",
+        "IX",
+    };
+
+    public static String generate(int number) {
+        if (number < MIN_VALUE || number > MAX_VALUE) {
+            throw new IllegalArgumentException(String.format("The number must be in the range [%d, %d]", MIN_VALUE, MAX_VALUE));
+        }
+
+        return (RN_M[number / 1000] + RN_C[number % 1000 / 100] + RN_X[number % 100 / 10] + RN_I[number % 10]);
+    }
+}

--- a/__src6/bearing.rs
+++ b/__src6/bearing.rs
@@ -1,0 +1,40 @@
+use std::f64::consts::PI;
+
+pub fn bearing(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
+    let lat1 = lat1 * PI / 180.0;
+    let lng1 = lng1 * PI / 180.0;
+
+    let lat2 = lat2 * PI / 180.0;
+    let lng2 = lng2 * PI / 180.0;
+
+    let delta_longitude = lng2 - lng1;
+
+    let y = delta_longitude.sin() * lat2.cos();
+    let x = lat1.cos() * lat2.sin() - lat1.sin() * lat2.cos() * delta_longitude.cos();
+
+    let mut brng = y.atan2(x);
+    brng = brng.to_degrees();
+
+    (brng + 360.0) % 360.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn testing() {
+        assert_eq!(
+            format!(
+                "{:.0}º",
+                bearing(
+                    -27.2020447088982,
+                    -49.631891179172555,
+                    -3.106362,
+                    -60.025826,
+                )
+            ),
+            "336º"
+        );
+    }
+}

--- a/__src6/kl_divergence_loss.rs
+++ b/__src6/kl_divergence_loss.rs
@@ -1,0 +1,37 @@
+//! # KL divergence Loss Function
+//!
+//! For a pair of actual and predicted probability distributions represented as vectors `actual` and `predicted`, the KL divergence loss is calculated as:
+//!
+//! `L = -Σ(actual[i] * ln(predicted[i]/actual[i]))` for all `i` in the range of the vectors
+//!
+//! Where `ln` is the natural logarithm function, and `Σ` denotes the summation over all elements of the vectors.
+//!
+//! ## KL divergence Loss Function Implementation
+//!
+//! This implementation takes two references to vectors of f64 values, `actual` and `predicted`, and returns the KL divergence loss between them.
+//!
+pub fn kld_loss(actual: &[f64], predicted: &[f64]) -> f64 {
+    // epsilon to handle if any of the elements are zero
+    let eps = 0.00001f64;
+    let loss: f64 = actual
+        .iter()
+        .zip(predicted.iter())
+        .map(|(&a, &p)| (a + eps) * ((a + eps) / (p + eps)).ln())
+        .sum();
+    loss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kld_loss() {
+        let test_vector_actual = vec![1.346112, 1.337432, 1.246655];
+        let test_vector = vec![1.033836, 1.082015, 1.117323];
+        assert_eq!(
+            kld_loss(&test_vector_actual, &test_vector),
+            0.7752789394328498
+        );
+    }
+}

--- a/__src6/modular_exponential.rs
+++ b/__src6/modular_exponential.rs
@@ -1,0 +1,136 @@
+/// Calculate the greatest common divisor (GCD) of two numbers and the
+/// coefficients of Bézout's identity using the Extended Euclidean Algorithm.
+///
+/// # Arguments
+///
+/// * `a` - One of the numbers to find the GCD of
+/// * `m` - The other number to find the GCD of
+///
+/// # Returns
+///
+/// A tuple (gcd, x1, x2) such that:
+/// gcd - the greatest common divisor of a and m.
+/// x1, x2 - the coefficients such that `a * x1 + m * x2` is equivalent to `gcd` modulo `m`.
+pub fn gcd_extended(a: i64, m: i64) -> (i64, i64, i64) {
+    if a == 0 {
+        (m, 0, 1)
+    } else {
+        let (gcd, x1, x2) = gcd_extended(m % a, a);
+        let x = x2 - (m / a) * x1;
+        (gcd, x, x1)
+    }
+}
+
+/// Find the modular multiplicative inverse of a number modulo `m`.
+///
+/// # Arguments
+///
+/// * `b` - The number to find the modular inverse of
+/// * `m` - The modulus
+///
+/// # Returns
+///
+/// The modular inverse of `b` modulo `m`.
+///
+/// # Panics
+///
+/// Panics if the inverse does not exist (i.e., `b` and `m` are not coprime).
+pub fn mod_inverse(b: i64, m: i64) -> i64 {
+    let (gcd, x, _) = gcd_extended(b, m);
+    if gcd == 1 {
+        // Ensure the modular inverse is positive
+        (x % m + m) % m
+    } else {
+        panic!("Inverse does not exist");
+    }
+}
+
+/// Perform modular exponentiation of a number raised to a power modulo `m`.
+/// This function handles both positive and negative exponents.
+///
+/// # Arguments
+///
+/// * `base` - The base number to be raised to the `power`
+/// * `power` - The exponent to raise the `base` to
+/// * `modulus` - The modulus to perform the operation under
+///
+/// # Returns
+///
+/// The result of `base` raised to `power` modulo `modulus`.
+pub fn modular_exponential(base: i64, mut power: i64, modulus: i64) -> i64 {
+    if modulus == 1 {
+        return 0; // Base case: any number modulo 1 is 0
+    }
+
+    // Adjust if the exponent is negative by finding the modular inverse
+    let mut base = if power < 0 {
+        mod_inverse(base, modulus)
+    } else {
+        base % modulus
+    };
+
+    let mut result = 1; // Initialize result
+    power = power.abs(); // Work with the absolute value of the exponent
+
+    // Perform the exponentiation
+    while power > 0 {
+        if power & 1 == 1 {
+            result = (result * base) % modulus;
+        }
+        power >>= 1; // Divide the power by 2
+        base = (base * base) % modulus; // Square the base
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_modular_exponential_positive() {
+        assert_eq!(modular_exponential(2, 3, 5), 3); // 2^3 % 5 = 8 % 5 = 3
+        assert_eq!(modular_exponential(7, 2, 13), 10); // 7^2 % 13 = 49 % 13 = 10
+        assert_eq!(modular_exponential(5, 5, 31), 25); // 5^5 % 31 = 3125 % 31 = 25
+        assert_eq!(modular_exponential(10, 8, 11), 1); // 10^8 % 11 = 100000000 % 11 = 1
+        assert_eq!(modular_exponential(123, 45, 67), 62); // 123^45 % 67
+    }
+
+    #[test]
+    fn test_modular_inverse() {
+        assert_eq!(mod_inverse(7, 13), 2); // Inverse of 7 mod 13 is 2
+        assert_eq!(mod_inverse(5, 31), 25); // Inverse of 5 mod 31 is 25
+        assert_eq!(mod_inverse(10, 11), 10); // Inverse of 10 mod 1 is 10
+        assert_eq!(mod_inverse(123, 67), 6); // Inverse of 123 mod 67 is 6
+        assert_eq!(mod_inverse(9, 17), 2); // Inverse of 9 mod 17 is 2
+    }
+
+    #[test]
+    fn test_modular_exponential_negative() {
+        assert_eq!(
+            modular_exponential(7, -2, 13),
+            mod_inverse(7, 13).pow(2) % 13
+        ); // Inverse of 7 mod 13 is 2, 2^2 % 13 = 4 % 13 = 4
+        assert_eq!(
+            modular_exponential(5, -5, 31),
+            mod_inverse(5, 31).pow(5) % 31
+        ); // Inverse of 5 mod 31 is 25, 25^5 % 31 = 25
+        assert_eq!(
+            modular_exponential(10, -8, 11),
+            mod_inverse(10, 11).pow(8) % 11
+        ); // Inverse of 10 mod 11 is 10, 10^8 % 11 = 10
+        assert_eq!(
+            modular_exponential(123, -5, 67),
+            mod_inverse(123, 67).pow(5) % 67
+        ); // Inverse of 123 mod 67 is calculated via the function
+    }
+
+    #[test]
+    fn test_modular_exponential_edge_cases() {
+        assert_eq!(modular_exponential(0, 0, 1), 0); // 0^0 % 1 should be 0 as the modulus is 1
+        assert_eq!(modular_exponential(0, 10, 1), 0); // 0^n % 1 should be 0 for any n
+        assert_eq!(modular_exponential(10, 0, 1), 0); // n^0 % 1 should be 0 for any n
+        assert_eq!(modular_exponential(1, 1, 1), 0); // 1^1 % 1 should be 0
+        assert_eq!(modular_exponential(-1, 2, 1), 0); // (-1)^2 % 1 should be 0
+    }
+}


### PR DESCRIPTION
63 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.